### PR TITLE
Fix comma in site.pp

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -13,7 +13,7 @@ Exec {
     '/bin',
     '/usr/sbin',
     '/sbin'
-  ]
+  ],
 
   environment => [
     "HOMEBREW_CACHE=${homebrew::cachedir}",


### PR DESCRIPTION
Previously, boxen runs were failing because the Exec resource default
was missing a comma after an attribute that wasn't the last attribute
in the block.  This commit adds that comma so Puppet doesn't throw a
syntax error.
