### PR TITLE
Ignore downloaded tarballs of apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /shared/*
 !/shared/README.md
 /vendor/gems/
+/vendor/puppet/cache


### PR DESCRIPTION
The `github` librarian provider downloads tarballs into the puppet cache before installing them.

This ignores those files so they don't show up in the Git status.
