### PR TITLE
More detailed documentation on how to include modules.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,49 @@ provide as optional installs under the
 tested to be compatible with Boxen. Use the `Puppetfile` to pull them
 in dependencies automatically whenever `boxen` is run. 
 
+### Including boxen modules from github (boxen/puppet-<name>)
+
+You must add the github information for your added Puppet module into your Puppetfile at the root of your
+boxen repo (ex. /path/to/your-boxen/Puppetfile):
+
+    # Core modules for a basic development environment. You can replace
+    # some/most of these if you want, but it's not recommended.
+
+    github "dnsmasq",  "1.0.0"
+    github "gcc",      "1.0.0"
+    github "git",      "1.0.0"
+    github "homebrew", "1.0.0"
+    github "hub",      "1.0.0"
+    github "inifile",  "0.9.0", :repo => "cprice-puppet/puppetlabs-inifile"
+    github "nginx",    "1.0.0"
+    github "nodejs",   "1.0.0"
+    github "nvm",      "1.0.0"
+    github "ruby",     "1.0.0"
+    github "stdlib",   "3.0.0", :repo => "puppetlabs/puppetlabs-stdlib"
+    github "sudo",     "1.0.0"
+    
+    # Optional/custom modules. There are tons available at
+    # https://github.com/boxen.
+    
+    github "java",     "1.0.5"
+    
+In the above snippet of a customized Puppetfile, the bottom line 
+includes the Java module from Github using the tag "1.0.5" from the github repository 
+"boxen/puppet-java".  The function "github" is defined at the top of the Puppetfile 
+and takes the name of the module, the version, and optional repo location:
+
+    def github(name, version, options = nil)
+      options ||= {}
+      options[:repo] ||= "boxen/puppet-#{name}"
+      mod name, version, :github_tarball => options[:repo]
+    end
+
+Now Puppet knows where to download the module from when you include it in your site.pp or mypersonal.pp file:
+
+    # include the java module referenced in my Puppetfile with the line
+    # github "java",     "1.0.5"
+    include java
+
 ### Node definitions
 
 Puppet has the concept of a 


### PR DESCRIPTION
I had trouble including modules and had to ask someone how to do it so I updated the README.md file to document how to do it in more detail.

The README.md has more detailed instructions on how to include modules from Github by editing your Puppetfile and site.pp files.

Puppetfile:  github   "java", "1.0.5"
site.pp:       include java
