### PR TITLE
work with EDITOR like 'mate -w'

### DIFF
--- a/script/boxen-my-config
+++ b/script/boxen-my-config
@@ -19,6 +19,6 @@ unless File.exist? path
   end
 end
 
-exec(editor, path) if editor && system("test -t 1")
+exec([editor, path].join(' ')) if editor && system("test -t 1")
 
 puts path


### PR DESCRIPTION
It's entirely possible that EDITOR will be set to something that includes parameters, like `emacs -nw` or `mate -w`. In those cases, you have to exec a string, because you can't pass something with arguments as the first argument to exec.
