### PR TITLE
speed up all invocations of boxen

### DIFF
--- a/script/boxen
+++ b/script/boxen
@@ -64,7 +64,7 @@ end
 
 # Make sure our local dependencies are up to date.
 
-strap = %w(script/bootstrap --deployment --local --without development:test)
+strap = %w(script/bootstrap --deployment --local --without development:test --no-cache)
 abort "Can't bootstrap, dependencies are outdated." unless system *strap
 
 # Set up our local configuration, deps, and load path.


### PR DESCRIPTION
when running Bundler, it just so happens that --local should (but does not) 
skip updating the gems in vendor/cache. explicitly skipping that update drops 
most of a second off of every run of boxen.
