### PR TITLE
Don't panic if your HEAD is detached

### DIFF
--- a/script/boxen
+++ b/script/boxen
@@ -39,13 +39,12 @@ unless ENV["BOXEN_NO_PULL"] || ARGV.include?("--no-pull")
     upstream_changes = `git rev-list --count master..origin/master`.chomp != '0'
     fast_forwardable = `git rev-list --count origin/master..master`.chomp == '0'
 
-    if !master
-      short_branch = if current_branch.empty?
-        `git log -1 --pretty=format:%h`
-      else
-        current_branch.split('/')[2..-1].join('/')
-      end
-      warn "Boxen on a non-master branch '#{short_branch}', won't auto-update!"
+    if current_branch.empty?
+      ref = `git log -1 --pretty=format:%h`
+      warn "Boxen not currently on any branch (ref: #{ref}), won't auto-update!"
+    elsif !master
+      local_branch =  current_branch.split('/')[2..-1].join('/')
+      warn "Boxen on a non-master branch '#{local_branch}', won't auto-update!"
     elsif !fast_forwardable
       warn "Boxen's master branch is out of sync, won't auto-update!"
     elsif !clean


### PR DESCRIPTION
Examples of situations when HEAD is not symbolic:
- You're doing interactive rebase
- You're using git bisect
- You love working with your head detached :smile: 
- ... and so on.

Before this fix, when you run `boxen`, you get a crash like this:

```
fatal: ref HEAD is not a symbolic ref
/opt/boxen/bin/boxen:42: undefined method `join' for nil:NilClass (NoMethodError)
```

After the fix, you merely get a warning:

```
fatal: ref HEAD is not a symbolic ref
Boxen on a non-master branch '549f113', won't auto-update!
```

What say y'all?
