### PR TITLE
Allow Bundler 1.x releases

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -5,8 +5,8 @@ set -e
 
 # FIX: only sudo if gem home isn't writable
 
-(gem spec bundler -v '~> 1.2.0' > /dev/null 2>&1) ||
-  sudo gem install bundler -v '~> 1.2.0' --no-rdoc --no-ri
+(gem spec bundler -v '~> 1.3' > /dev/null 2>&1) ||
+  sudo gem install bundler -v '~> 1.3' --no-rdoc --no-ri
 
 # We don't want old config hanging around.
 


### PR DESCRIPTION
Since Bundler is going to be fully compatible for all 1.x releases (yes, I will yank versions that break this), check for and install a 1.x version of Bundler that is at least 1.3 or higher.
