### PR TITLE
.projects should be ignored by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.bundle
 /.librarian
+/.projects
 /.snapshot
 /.tmp
 /bin


### PR DESCRIPTION
.projects should be ignored by default based on https://github.com/boxen/our-boxen/issues/48#issuecomment-13660086
