### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.librarian
 /.snapshot
 /.tmp
+/.projects
 /bin
 /config/local.rb
 /log


### PR DESCRIPTION
.projects should probably be in the gitignore, otherwise causing unclean tree errors if script/boxen fails mid-way
