### PR TITLE
Use the boxen-git-credential for all repositories clones.

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -39,7 +39,10 @@ Repository {
   extra    => [
     '--recurse-submodules'
   ],
-  require  => Class['git']
+  require  => Class['git'],
+  config   => {
+    'credential.helper' => "${boxen::config::bindir}/boxen-git-credential"
+  }
 }
 
 Service {


### PR DESCRIPTION
This is required since puppet run all the comands as root and the credential config is only present on the user land.

The lack of this configuration is making clones using https to not work since the credential is not present for the root.

Closes #286
