### PR TITLE
Set the global node version in the site manifest

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -69,6 +69,11 @@ node default {
   include nodejs::v0_8
   include nodejs::v0_10
 
+  # set the global node version
+  class { 'nodejs::global':
+    version => 'v0.10'
+  }
+
   # default ruby versions
   include ruby::1_8_7
   include ruby::1_9_2


### PR DESCRIPTION
It doesn't look like the global node version gets set anywhere. I had to add this change to our site manifest to fix.

Before:

```
Last login: Wed Jun 19 11:39:04 on ttys002
nodenv: couldn't find any version specified for use
smcnabb@mac:~ $ node --version
nodenv: couldn't find any version specified for use
smcnabb@mac:~ $ nodenv version
nodenv: couldn't find any version specified for use
smcnabb@mac:~ $ set | grep NODE
NODENV_ROOT=/opt/boxen/nodenv
NODE_PATH=/opt/boxen/nodenv/versions//lib/
```

After:

```
Last login: Wed Jun 19 11:39:14 on ttys002
smcnabb@mac:~ $ node --version
v0.10.7
smcnabb@mac:~ $ nodenv version
v0.10
smcnabb@mac:~ $ set | grep NODE
NODENV_ROOT=/opt/boxen/nodenv
NODE_PATH=/opt/boxen/nodenv/versions/v0.10/lib/
```
