### PR TITLE
Change nginx.conf.erb to silence warnings

### DIFF
--- a/modules/projects/templates/shared/nginx.conf.erb
+++ b/modules/projects/templates/shared/nginx.conf.erb
@@ -1,19 +1,19 @@
-upstream <%= server_name %> {
- server unix:<%= scope.lookupvar "boxen::config::socketdir" %>/<%= name %>;
+upstream <%= @server_name %> {
+ server unix:<%= scope.lookupvar "boxen::config::socketdir" %>/<%= @name %>;
 }
 
 server {
-  access_log <%= scope.lookupvar "nginx::config::logdir" %>/<%= name %>.access.log main;
+  access_log <%= scope.lookupvar "nginx::config::logdir" %>/<%= @name %>.access.log main;
   listen 80;
-  root <%= scope.lookupvar "boxen::config::srcdir" %>/<%= name %>/public;
-  server_name <%= server_name %>;
+  root <%= scope.lookupvar "boxen::config::srcdir" %>/<%= @name %>/public;
+  server_name <%= @server_name %>;
 
   client_max_body_size 50M;
 
   error_page 500 502 503 504 /50x.html;
 
   if ($host ~* "www") {
-    rewrite ^(.*)$ http://<%= server_name %>$1 permanent;
+    rewrite ^(.*)$ http://<%= @server_name %>$1 permanent;
     break;
   }
 
@@ -31,7 +31,7 @@ server {
     }
 
     if (!-f $request_filename) {
-      proxy_pass http://<%= server_name %>;
+      proxy_pass http://<%= @server_name %>;
       break;
     }
   }


### PR DESCRIPTION
`server_name` and `name` without '@' were causing deprecation warnings.
