### PR TITLE
Changing nginx template to use try_files

### DIFF
--- a/modules/projects/templates/shared/nginx.conf.erb
+++ b/modules/projects/templates/shared/nginx.conf.erb
@@ -11,6 +11,11 @@ server {
   client_max_body_size 50M;
   error_page 500 502 503 504 /50x.html;
 
+  if ($host ~* "www") {
+    rewrite ^(.*)$ http://<%= @server_name %>$1 permanent;
+    break;
+  }
+
   location = /50x.html {
     root html;
   }


### PR DESCRIPTION
`try_files` is the preferred method for Nginx configs so offering up this PR to change out the `if` blocks for `try_files` instead. 
