### PR TITLE
Add Nginx wildcard subdomain to projects template

### DIFF
--- a/modules/projects/templates/shared/nginx.conf.erb
+++ b/modules/projects/templates/shared/nginx.conf.erb
@@ -11,15 +11,10 @@ server {
   client_max_body_size 50M;
   error_page 500 502 503 504 /50x.html;
 
-  if ($host ~* "www") {
-    rewrite ^(.*)$ http://<%= @server_name %>$1 permanent;
-    break;
-  }
-
   location = /50x.html {
     root html;
   }
-  
+
   try_files $uri/index.html $uri @<%= @server_name %>;
   location @<%= @server_name %> {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Submitting this as I was used to the default behaviour of [Pow](http://pow.cx/manual.html#section_2.1.1). This will accept all subdomain requests for a project.

With Nginx this `.<%= @server_name %>` would match both the exact name and the wildcard but I believe separately it is more obvious what we are listening for.

An [exact name will also override a wildcard match](http://wiki.nginx.org/HttpCoreModule#server_name) so there will be no conflict.

The removal of the "www" if block was because it appears to serve no purpose, and if you want a redirect for `www.` there is a more efficient method:

``` nginx
server {
  server_name www.<%= @server_name %>;
  return 301 $scheme://$host$request_uri;
}
```
