### PR TITLE
don't auto-update on some local-only operations

### DIFF
--- a/script/boxen
+++ b/script/boxen
@@ -25,9 +25,9 @@ Dir.chdir Pathname.new(__FILE__).realpath + "../.."
 
 # Auto-update code. This is done as early as possible so that changes
 # to boxen support code or dependencies can be grabbed.
-NO_PULL_ARGS = %w[--no-pull -h -? --help]
+NO_PULL_ARGS = %w[--no-pull -h -? --help] + [/-service/]
 unless ENV["BOXEN_NO_PULL"] ||
-  ARGV.any? { |arg|  NO_PULL_ARGS.include?(arg) }
+  ARGV.any? { |arg|  NO_PULL_ARGS.any? { |no|  arg.match(no) } }
   quietly = "> /dev/null 2>&1"
 
   if system("which git > /dev/null") && File.directory?(".git") \


### PR DESCRIPTION
There are some local-only operations (getting help, messing with services) that can't be done when you're without connectivity, since boxen will attempt to auto-update itself first. There's actually a `--no-pull` arg, but it's hard to know about that since you can't even get the help without auto-updating.

So this turns off auto-updating for help and for enabling/disabling/restarting services.

This will fix boxen/boxen#95 if accepted.

Also, let's not talk at all about how I accidentally committed these to master before pulling back and making this PR. It never happened.
