### PR TITLE
Should use repo_dir variable in nginx template

### DIFF
--- a/modules/projects/templates/shared/nginx.conf.erb
+++ b/modules/projects/templates/shared/nginx.conf.erb
@@ -5,7 +5,7 @@ upstream <%= @server_name %> {
 server {
   access_log <%= scope.lookupvar "nginx::config::logdir" %>/<%= @name %>.access.log main;
   listen 80;
-  root <%= scope.lookupvar "boxen::config::srcdir" %>/<%= @name %>/public;
+  root <%= @repo_dir %>/public;
   server_name <%= @server_name %> *.<%= @server_name %>;
 
   client_max_body_size 50M;


### PR DESCRIPTION
Noticed `@repo_dir` is used throughout the puppet manifest but the template does not make any reference to it.

https://github.com/boxen/puppet-boxen/blob/master/manifests/project.pp#L85
