### PR TITLE
Adding more lines to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 /shared/*
 !/shared/README.md
 /vendor/gems/
+/vendor/puppet/cache/
+/vendor/puppet/source/


### PR DESCRIPTION
These paths are used to cache files by librarian-puppet.  Without
these extra lines boxen will complain about a dirty path and will
not automatically pull from the repo on update.
