### PR TITLE
force UTF-8 encoding in credential helper

### DIFF
--- a/script/boxen-git-credential
+++ b/script/boxen-git-credential
@@ -8,6 +8,10 @@ end
 
 require "pathname"
 
+# It's a UTF-8, UTF-8, UTF-8 world.
+
+Encoding.default_external = Encoding::UTF_8
+
 # Put us where we belong, in the root dir of our boxen repo.
 
 Dir.chdir Pathname.new(__FILE__).realpath + "../.."


### PR DESCRIPTION
This fixes boxen/boxen#127 by forcing the git credential helper to always use UTF-8 encoding. Apparently sudo doesn't believe in UTF-8.
