### PR TITLE
Remove node v0.4 because it fails on 10.9

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -64,7 +64,6 @@ node default {
   }
 
   # node versions
-  include nodejs::v0_4
   include nodejs::v0_6
   include nodejs::v0_8
   include nodejs::v0_10


### PR DESCRIPTION
Lots of people getting tripped up on this on Mavericks because it's in the example.
