### PR TITLE
ensure bootstrap uses system ruby

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -25,3 +25,6 @@ set -e
 
 # Bundle install unless we're already up to date.
 /usr/bin/bundle install --binstubs bin --path .bundle --quiet "$@"
+
+# Fix the binstubs to use system ruby
+find bin -type f -print0 | xargs -0 sed -i '' 's|/usr/bin/env ruby|/usr/bin/ruby|g'


### PR DESCRIPTION
turns out that because chruby changes the PATH, you can
run boxen and the bootstrap script will still use chruby.
that causes segfaults, and is very sad.
