### PR TITLE
Unbreak boxen-git-credential on 10.8 systems

### DIFF
--- a/script/boxen-git-credential
+++ b/script/boxen-git-credential
@@ -10,7 +10,7 @@ require "pathname"
 
 # It's a UTF-8, UTF-8, UTF-8 world.
 
-Encoding.default_external = Encoding::UTF_8
+Encoding.default_external = Encoding::UTF_8 if RUBY_VERSION > "1.9"
 
 # Put us where we belong, in the root dir of our boxen repo.
 


### PR DESCRIPTION
PR https://github.com/boxen/our-boxen/pull/448 uses Ruby's Encoding class to help sudo preserve environment variables. However this breaks on OS X 10.8 as it ships with Ruby 1.8.7, which doesn't have the encoding class available: https://github.com/boxen/our-boxen/issues/474

This adds a quick conditional to ensure RUBY_VERSION > 1.9 before attempting to set Encoding, to allow this to work on >= OS X 10.8.
