### PR TITLE
Clarify where to create the new git repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ How do you do it?
 
 ### Bootstrapping
 
-Create a **new** git repository somewhere.
+Create a **new** git repository somewhere on the internet.
 It can be private or public -- it really doesn't matter.
 If you're making a repository on GitHub, you _may not_ want to fork this repo
 to get started.


### PR DESCRIPTION
Be more explicit about where the new repo should be located. It's much
easier to set up a repo on the internet. This was implied before and now
it's explicit.

The first time I helped a colleague set this up, we used a local repo.
Since we didn't know what we were doing, we screwed it up pretty badly.
This bit of text might allow others not to make the same mistake we did.

Thanks! :heart:
