### PR TITLE
Clarify the installation steps after bootstrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,18 @@ git remote add origin <the location of my new git repository>
 git push -u origin master
 ```
 
+Now that your boxen is bootstrapped, you can run the following to
+install the default configuration from this repo:
+
+```
+cd /opt/boxen/repo
+script/boxen
+```
+
+You can also skip the above steps and <a href="#customizing">customize your
+boxen</a> before installing it.
+
+
 ### Distributing
 
 That's enough to get your boxen into a usable state on other machines,


### PR DESCRIPTION
Make it clearer on how to install a boxen from the command line after the bootstrapping steps are done.

I believe this makes it easier for the impatient people among us (like myself :smiley:) that don't really want to set up boxen-web for a single box install since we'll already be on the command line.
