### PR TITLE
Update Puppetfile#github to accept refs.

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -14,6 +14,9 @@ def github(name, *args)
 
   if path = options.delete(:path)
     mod name, :path => path
+  elsif repo = options.delete(:git)
+    ref = options.delete(:ref) || 'master'
+    mod name, :git => repo, :ref => ref 
   else
     version = args.first
     options[:repo] ||= "boxen/puppet-#{name}"


### PR DESCRIPTION
For users of GitHub Enterprise we're going to want to explicitly specify the git repository location of internal puppet modules for boxen. This is also beneficial for forks of the boxen organization modules, etc. 
