### PR TITLE
Remove usernames with a dash warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ and detect most of these and tell you anyway):
 
 * Boxen __requires__ at least the Xcode Command Line Tools installed.
 * Boxen __will not__ work with an existing rvm install.
-* Boxen __may not__ play nice with a GitHub username that includes dash(-)
 * Boxen __may not__ play nice with an existing rbenv install.
 * Boxen __may not__ play nice with an existing chruby install.
 * Boxen __may not__ play nice with an existing homebrew install.


### PR DESCRIPTION
Boxen seems to play just fine with usernames with a dash. I should know. I
have a username with a dash. :moneybag:

If you don't have enough other data from folks with dashes in their username
and don't want to merge this, that's totally cool. I'm just throwing
this out here and see if it sticks anyways. :smiley:
