### PR TITLE
Fix to work with GNU sed

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -27,4 +27,4 @@ set -e
 /usr/bin/bundle install --binstubs bin --path .bundle --quiet "$@"
 
 # Fix the binstubs to use system ruby
-find bin -type f -print0 | xargs -0 sed -i '' 's|/usr/bin/env ruby|/usr/bin/ruby|g'
+find bin -type f -print0 | xargs -0 sed -i'' 's|/usr/bin/env ruby|/usr/bin/ruby|g'


### PR DESCRIPTION
This will fix bootstrap script to work with GNU sed. 

(for example when you install sed formula with homebrew `--default-names` to have precedence over BSD one like: `brew install gnu-sed --default-names`)
