### PR TITLE
Remove unneeded code from the MySQL example

### DIFF
--- a/docs/rails.md
+++ b/docs/rails.md
@@ -52,8 +52,6 @@ your app best to work with Boxen.
 # config/database.yml
 
 <%
-  def boxen?; ENV['BOXEN_HOME']; end
-
   socket = [
     ENV["BOXEN_MYSQL_SOCKET"],
     "/var/run/mysql5/mysqld.sock",


### PR DESCRIPTION
The `boxen?` method isn't used anywhere in the file. Remove it so that there's less code for people to copy and paste and to generate less confusion as to why there's a method there that doesn't need to be there.
