### PR TITLE
Don't let .DS_Store files break script/bootstrap

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -27,4 +27,4 @@ set -e
 /usr/bin/bundle install --binstubs bin --path .bundle --quiet "$@"
 
 # Fix the binstubs to use system ruby
-find bin -type f -print0 | xargs -0 sed -i '' 's|/usr/bin/env ruby|/usr/bin/ruby|g'
+find bin -not -path 'bin/\.*' -type f -print0 | xargs -0 sed -i '' 's|/usr/bin/env ruby|/usr/bin/ruby|g'


### PR DESCRIPTION
Fixes boxen/our-boxen#512

In particular, I have seen problems with the following hidden files that Mac creates:
- `.DS_Store`
- `.!59508!.DS_Store`
- `.!59554!.DS_Store`
