### PR TITLE
Fix "Unable to find module 'ripienaa/puppet-module-data' on https://github.com"

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -33,7 +33,7 @@ github "boxen", "3.4.2"
 
 # Support for default hiera data in modules
 
-github "module-data", "0.0.3", :repo => "ripienaa/puppet-module-data"
+github "module-data", "0.0.3", :repo => "ripienaar/puppet-module-data"
 
 # Core modules for a basic development environment. You can replace
 # some/most of these if you want, but it's not recommended.


### PR DESCRIPTION
Typo in module address, I believe "ripienaar/puppet-module-data" is correct. This causes boxen to fail on librarian like:

```
Unable to find module 'ripienaa/puppet-module-data' on https://github.com
Can't run Puppet, fetching dependencies with librarian failed.
```
