### PR TITLE
Fix for when is GNU sed installed in homebrew with --default-names

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -27,4 +27,4 @@ set -e
 /usr/bin/bundle install --binstubs bin --path .bundle --quiet "$@"
 
 # Fix the binstubs to use system ruby
-find bin -not -path 'bin/\.*' -type f -print0 | xargs -0 sed -i '' 's|/usr/bin/env ruby|/usr/bin/ruby|g'
+find bin -not -path 'bin/\.*' -type f -print0 | xargs -0 /usr/bin/sed -i '' 's|/usr/bin/env ruby|/usr/bin/ruby|g'


### PR DESCRIPTION
This will fix issue when GNU sed is installed in $PATH with --default-names options, as -i between GNU and BSD versions of sed are not compatible.
