### PR TITLE
Fix to support LLVM/ruby that ships with Xcode 5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,20 +81,6 @@ cd /opt/boxen/repo
 ./script/boxen
 ```
 
-**Note**
-If you are creating a fresh install on Xcode 5.1 there is a clang issue with
-certain Ruby Gems. There is a Stackoverflow post [here](http://stackoverflow.com/questions/22352838/ruby-gem-install-json-fails-on-mavericks-and-xcode-5-1-unknown-argument-mul)
-
-To run the Boxen script follow these instructions
-```
-cd /opt/boxen/repo
-ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future ./script/boxen
-```
-
-You can also skip the above steps and <a href="#customizing">customize your
-boxen</a> before installing it.
-
-
 ### Distributing
 
 That's enough to get your boxen into a usable state on other machines,

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -23,8 +23,16 @@ if [ $? -eq 0 ]; then
 fi
 set -e
 
+CLT_VERSION=`pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | grep version | cut -f 2 -d ' ' | awk ' { print $1; } '`
+
 # Bundle install unless we're already up to date.
-/usr/bin/bundle install --binstubs bin --path .bundle --quiet "$@"
+if [[ $CLT_VERSION =~ ^5\.1\.0\.0\.1\.1396320587 ]]; then
+  # Fix for LLVM that ships with Xcode 5.1
+  ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future /usr/bin/bundle install --binstubs bin --path .bundle --quiet "$@"
+else
+  /usr/bin/bundle install --binstubs bin --path .bundle --quiet "$@"
+fi
+
 
 # Fix the binstubs to use system ruby
 find bin -not -path 'bin/\.*' -type f -print0 | xargs -0 /usr/bin/sed -i '' 's|/usr/bin/env ruby|/usr/bin/ruby|g'


### PR DESCRIPTION
Already added this check to boxen-web (https://github.com/boxen/boxen-web/pull/52). Currently checks for the exact version of Xcode that introduced the LLVM/Ruby issue. Didn't want to be too overzealous in matching for versions newer than this since the problem is dealt with in newer versions of Ruby.
