### PR TITLE
Suppressing error message when CLTools not installed

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -23,7 +23,7 @@ if [ $? -eq 0 ]; then
 fi
 set -e
 
-CLT_VERSION=`pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | grep version | cut -f 2 -d ' ' | awk ' { print $1; } '`
+CLT_VERSION=`pkgutil --pkg-info=com.apple.pkg.CLTools_Executables 2>/dev/null | grep version | cut -f 2 -d ' ' | awk ' { print $1; } '`
 
 # Bundle install unless we're already up to date.
 if [[ $CLT_VERSION =~ ^5\.1\.0\.0\.1\.1396320587 ]]; then


### PR DESCRIPTION
On Mavericks you can install full Xcode and Boxen, but then you get this line every time you run `boxen` on the command-line:

```
No receipt for 'com.apple.pkg.CLTools_Executables' found at '/'.
```

This minor bugfix suppresses the message.
