### PR TITLE
Fix for git credentials containing an '=' sign

### DIFF
--- a/script/boxen-git-credential
+++ b/script/boxen-git-credential
@@ -28,7 +28,7 @@ require "boxen/config"
 
 config = Boxen::Config.load
 input  = $stdin.read
-attrs  = Hash[input.split($/).map { |l| l.split("=") }]
+attrs  = Hash[input.split($/).map { |l| l.split("=", 2) }]
 # find GitHub or GitHub Enterprise host
 ghhost = URI(config.ghurl).host
 


### PR DESCRIPTION
Thanks @dbussink
