### PR TITLE
Rename `module-data` to `module_data`

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -33,7 +33,7 @@ github "boxen", "3.6.2"
 
 # Support for default hiera data in modules
 
-github "module-data", "0.0.3", :repo => "ripienaar/puppet-module-data"
+github "module_data", "0.0.3", :repo => "ripienaar/puppet-module-data"
 
 # Core modules for a basic development environment. You can replace
 # some/most of these if you want, but it's not recommended.

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -96,7 +96,7 @@ GITHUBTARBALL
 GITHUBTARBALL
   remote: ripienaar/puppet-module-data
   specs:
-    module-data (0.0.3)
+    module_data (0.0.3)
 
 DEPENDENCIES
   boxen (= 3.6.2)
@@ -108,7 +108,7 @@ DEPENDENCIES
   homebrew (= 1.9.4)
   hub (= 1.3.0)
   inifile (= 1.0.3)
-  module-data (= 0.0.3)
+  module_data (= 0.0.3)
   nginx (= 1.4.3)
   nodejs (= 3.8.1)
   openssl (= 1.0.0)


### PR DESCRIPTION
This came up in rodjek/librarian-puppet#242. A `-` is not a valid character in module names according to http://docs.puppetlabs.com/puppet/latest/reference/modules_fundamentals.html#allowed-module-names In the Modulefile for ripienaar/puppet-module-data, the name actually contains an underscore.

Thanks @hanjianwei for noticing this and tracking down the naming rules
