### PR TITLE
Install NodeJS using `nodejs::version`

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -64,9 +64,9 @@ node default {
   }
 
   # node versions
-  include nodejs::v0_6
-  include nodejs::v0_8
-  include nodejs::v0_10
+  nodejs::version { 'v0_6': }
+  nodejs::version { 'v0_8': }
+  nodejs::version { 'v0_10': }
 
   # default ruby versions
   ruby::version { '1.9.3': }


### PR DESCRIPTION
The latest major release of puppet-nodejs, removed the versions classes:

```
https://github.com/boxen/puppet-nodejs/releases
```

Cc: @tarebyte, @rafaelfranca
