### PR TITLE
Fix dev module name mask

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -23,7 +23,7 @@ end
 
 # Shortcut for a module under development
 def dev(name, *args)
-  mod name, :path => "#{ENV['HOME']}/src/boxen/puppet-#{name}"
+  mod "puppet-#{name}", :path => "#{ENV['HOME']}/src/boxen/puppet-#{name}"
 end
 
 # Includes many of our custom types and providers, as well as global


### PR DESCRIPTION
When you try using the `dev` shortcut in `Puppetfile`, e.g.

```
github "gcc", "2.2.0"
dev "brewcask"
```
you'll see following warnings:
```
Invalid module name 'brewcask', you should qualify it with 'ORGANIZATION-brewcask' for resolution to work correctly
```

It's basically harmless, but annoying and this PR changes the name of the module from `modulename` to `puppet-modulename` -> therefore prevents these warnings.