### PR TITLE
Adds Beaker for acceptance testing of Boxen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /shared/*
 !/shared/README.md
 /vendor/gems/
+.vagrant/

--- a/script/setup-keychain.sh
+++ b/script/setup-keychain.sh
@@ -1,0 +1,8 @@
+echo "Setting up keychain..."
+
+if [[ `security list-keychains | grep default | wc -l` -eq 0 ]]; then
+  security create-keychain -p vagrant default
+fi
+
+security default-keychain -d user -s default
+security unlock-keychain -p vagrant

--- a/script/setup-keychain.sh
+++ b/script/setup-keychain.sh
@@ -1,8 +1,12 @@
-echo "Setting up keychain..."
-
 if [[ `security list-keychains | grep default | wc -l` -eq 0 ]]; then
+  echo "Setting up keychain..."
+
   security create-keychain -p vagrant default
+  security default-keychain -d user -s default
+
+  # Overriding default settings (lock-on-sleep timeout=300s)
+  security set-keychain-settings default
 fi
 
-security default-keychain -d user -s default
+echo "Unlocking keychain..."
 security unlock-keychain -p vagrant

--- a/script/xcode-cli-tools.sh
+++ b/script/xcode-cli-tools.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+# Get and install Xcode CLI tools
+OSX_VERS=$(sw_vers -productVersion | awk -F "." '{print $2}')
+
+# on 10.9+, we can leverage SUS to get the latest CLI tools
+if [ "$OSX_VERS" -ge 9 ]; then
+    # create the placeholder file that's checked by CLI updates' .dist code
+    # in Apple's SUS catalog
+    touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
+    # find the CLI Tools update
+    PROD=$(softwareupdate -l | grep "\*.*Command Line" | head -n 1 | awk -F"*" '{print $2}' | sed -e 's/^ *//' | tr -d '\n')
+    # install it
+    softwareupdate -i "$PROD" -v
+
+# on 10.7/10.8, we instead download from public download URLs, which can be found in
+# the dvtdownloadableindex:
+# https://devimages.apple.com.edgekey.net/downloads/xcode/simulators/index-3905972D-B609-49CE-8D06-51ADC78E07BC.dvtdownloadableindex
+else
+    [ "$OSX_VERS" -eq 7 ] && DMGURL=http://devimages.apple.com/downloads/xcode/command_line_tools_for_xcode_os_x_lion_april_2013.dmg
+    [ "$OSX_VERS" -eq 8 ] && DMGURL=http://devimages.apple.com/downloads/xcode/command_line_tools_for_osx_mountain_lion_april_2014.dmg
+
+    TOOLS=clitools.dmg
+    curl "$DMGURL" -o "$TOOLS"
+    TMPMOUNT=`/usr/bin/mktemp -d /tmp/clitools.XXXX`
+    hdiutil attach "$TOOLS" -mountpoint "$TMPMOUNT"
+    installer -pkg "$(find $TMPMOUNT -name '*.mpkg')" -target /
+    hdiutil detach "$TMPMOUNT"
+    rm -rf "$TMPMOUNT"
+    rm "$TOOLS"
+    exit
+fi

--- a/spec/Gemfile.beaker
+++ b/spec/Gemfile.beaker
@@ -1,0 +1,8 @@
+source "https://rubygems.org"
+
+group :system_tests do
+  gem 'beaker', :github => 'puppetlabs/beaker', :require => false
+  gem 'beaker-boxen', :github => 'petems/beaker-boxen', :require => false
+  gem 'beaker-rspec', :github => 'puppetlabs/beaker-rspec', :require => false
+  gem 'serverspec', :github => 'serverspec/serverspec', :require => false
+end

--- a/spec/Gemfile.beaker.lock
+++ b/spec/Gemfile.beaker.lock
@@ -1,0 +1,235 @@
+GIT
+  remote: git://github.com/petems/beaker-boxen.git
+  revision: d39cf56a463aeee5f458fe3b1b1002d69c514e3f
+  specs:
+    beaker-boxen (0.0.1)
+      beaker
+
+GIT
+  remote: git://github.com/puppetlabs/beaker-rspec.git
+  revision: 7a64f285bf84965a409d3393ae27544e8dbd0d99
+  specs:
+    beaker-rspec (5.0.1)
+      beaker (~> 2.0)
+      rspec
+      serverspec (~> 2)
+      specinfra (~> 2)
+
+GIT
+  remote: git://github.com/puppetlabs/beaker.git
+  revision: badb17a002aca18487b4cffaee197515972bdd9b
+  specs:
+    beaker (2.4.1)
+      aws-sdk (~> 1.57)
+      docker-api
+      fission (~> 0.4)
+      fog (~> 1.25)
+      google-api-client (~> 0.7)
+      hocon (~> 0.0.4)
+      inifile (~> 2.0)
+      json (~> 1.8)
+      minitest (~> 5.4)
+      net-scp (~> 1.2)
+      net-ssh (~> 2.9)
+      rbvmomi (~> 1.8)
+      unf (~> 0.1)
+
+GIT
+  remote: git://github.com/serverspec/serverspec.git
+  revision: e49f46901b264c7d0ec3995c2735e7ca3ad2940a
+  specs:
+    serverspec (2.8.2)
+      multi_json
+      rspec (~> 3.0)
+      rspec-its
+      specinfra (~> 2.12)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    CFPropertyList (2.3.0)
+    activesupport (4.2.0)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    addressable (2.3.7)
+    archive-tar-minitar (0.5.2)
+    autoparse (0.3.3)
+      addressable (>= 2.3.1)
+      extlib (>= 0.9.15)
+      multi_json (>= 1.0.0)
+    aws-sdk (1.63.0)
+      aws-sdk-v1 (= 1.63.0)
+    aws-sdk-v1 (1.63.0)
+      json (~> 1.4)
+      nokogiri (>= 1.4.4)
+    builder (3.2.2)
+    diff-lcs (1.2.5)
+    docker-api (1.19.0)
+      archive-tar-minitar
+      excon (>= 0.38.0)
+      json
+    excon (0.44.2)
+    extlib (0.9.16)
+    faraday (0.9.1)
+      multipart-post (>= 1.2, < 3)
+    fission (0.5.0)
+      CFPropertyList (~> 2.2)
+    fog (1.28.0)
+      fog-atmos
+      fog-aws (~> 0.0)
+      fog-brightbox (~> 0.4)
+      fog-core (~> 1.27, >= 1.27.3)
+      fog-ecloud
+      fog-json
+      fog-profitbricks
+      fog-radosgw (>= 0.0.2)
+      fog-riakcs
+      fog-sakuracloud (>= 0.0.4)
+      fog-serverlove
+      fog-softlayer
+      fog-storm_on_demand
+      fog-terremark
+      fog-vmfusion
+      fog-voxel
+      fog-xml (~> 0.1.1)
+      ipaddress (~> 0.5)
+      nokogiri (~> 1.5, >= 1.5.11)
+    fog-atmos (0.1.0)
+      fog-core
+      fog-xml
+    fog-aws (0.1.0)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-brightbox (0.7.1)
+      fog-core (~> 1.22)
+      fog-json
+      inflecto (~> 0.0.2)
+    fog-core (1.29.0)
+      builder
+      excon (~> 0.38)
+      formatador (~> 0.2)
+      mime-types
+      net-scp (~> 1.1)
+      net-ssh (>= 2.1.3)
+    fog-ecloud (0.0.2)
+      fog-core
+      fog-xml
+    fog-json (1.0.0)
+      multi_json (~> 1.0)
+    fog-profitbricks (0.0.1)
+      fog-core
+      fog-xml
+      nokogiri
+    fog-radosgw (0.0.3)
+      fog-core (>= 1.21.0)
+      fog-json
+      fog-xml (>= 0.0.1)
+    fog-riakcs (0.1.0)
+      fog-core
+      fog-json
+      fog-xml
+    fog-sakuracloud (1.0.0)
+      fog-core
+      fog-json
+    fog-serverlove (0.1.1)
+      fog-core
+      fog-json
+    fog-softlayer (0.4.1)
+      fog-core
+      fog-json
+    fog-storm_on_demand (0.1.0)
+      fog-core
+      fog-json
+    fog-terremark (0.0.4)
+      fog-core
+      fog-xml
+    fog-vmfusion (0.0.1)
+      fission
+      fog-core
+    fog-voxel (0.0.2)
+      fog-core
+      fog-xml
+    fog-xml (0.1.1)
+      fog-core
+      nokogiri (~> 1.5, >= 1.5.11)
+    formatador (0.2.5)
+    google-api-client (0.8.2)
+      activesupport (>= 3.2)
+      addressable (~> 2.3)
+      autoparse (~> 0.3)
+      extlib (~> 0.9)
+      faraday (~> 0.9)
+      launchy (~> 2.4)
+      multi_json (~> 1.10)
+      retriable (~> 1.4)
+      signet (~> 0.6)
+    hocon (0.0.7)
+    i18n (0.7.0)
+    inflecto (0.0.2)
+    inifile (2.0.2)
+    ipaddress (0.8.0)
+    json (1.8.2)
+    jwt (1.2.1)
+    launchy (2.4.3)
+      addressable (~> 2.3)
+    mime-types (2.4.3)
+    mini_portile (0.6.2)
+    minitest (5.5.1)
+    multi_json (1.10.1)
+    multipart-post (2.0.0)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-ssh (2.9.2)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
+    rbvmomi (1.8.2)
+      builder
+      nokogiri (>= 1.4.1)
+      trollop
+    retriable (1.4.1)
+    rspec (3.2.0)
+      rspec-core (~> 3.2.0)
+      rspec-expectations (~> 3.2.0)
+      rspec-mocks (~> 3.2.0)
+    rspec-core (3.2.0)
+      rspec-support (~> 3.2.0)
+    rspec-expectations (3.2.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-its (1.1.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.2.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-support (3.2.1)
+    signet (0.6.0)
+      addressable (~> 2.3)
+      extlib (~> 0.9)
+      faraday (~> 0.9)
+      jwt (~> 1.0)
+      multi_json (~> 1.10)
+    specinfra (2.12.6)
+      net-scp
+      net-ssh
+    thread_safe (0.3.4)
+    trollop (2.1.1)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.6)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  beaker!
+  beaker-boxen!
+  beaker-rspec!
+  serverspec!

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,0 +1,16 @@
+# Beaker tests
+
+Beaker is a tool to run given Puppet code on a
+
+These Beaker tests download an OSX Vagrant Box, then copy over the `our-boxen` directory, then run
+
+# How
+
+In this directory, run:
+
+  $ bundle install --gemfile spec/Gemfile.beaker
+
+When the install completes, run a given acceptance test:
+
+  $ BUNDLE_GEMFILE=spec/Gemfile.beaker bundle exec rspec spec/acceptance/sanity_spec.rb
+

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,0 +1,13 @@
+HOSTS:
+  osx-1010-x64:
+    roles:
+      - master
+    platform: osx-1010-x64
+    box : osx-yosemite-0.2.0
+    box_url : http://files.dryga.com/boxes/osx-yosemite-0.2.0.box
+    hypervisor : boxen
+    user : vagrant
+CONFIG:
+  log_level : debug
+  type: git
+  configure : false

--- a/spec/acceptance/sanity_spec.rb
+++ b/spec/acceptance/sanity_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper_acceptance'
+
+describe 'boxen' do
+
+  context 'sanity check' do
+    it 'runs with no errors' do
+      shell("cd /opt/boxen/repo && BOXEN_NO_PULL=true ./script/boxen --no-fde --debug --token=#{ENV['GITHUB_API_TOKEN']}", :acceptable_exit_codes => [0,2]) do | cmd |
+        expect(cmd.stdout).to_not match(/has failures: true/)
+      end
+    end
+  end
+end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,0 +1,39 @@
+require 'beaker-rspec'
+
+UNSUPPORTED_PLATFORMS = [ 'windows', 'Solaris' ]
+
+unless ENV['RS_PROVISION'] == 'no' or ENV['BEAKER_provision'] == 'no'
+  hosts.each do |host|
+    shell('sudo mkdir -p /opt/boxen', :acceptable_exit_codes => [0])
+    shell('sudo chown vagrant:staff /opt/boxen', :acceptable_exit_codes => [0])
+  end
+end
+
+RSpec.configure do |c|
+  # Project root
+  proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+
+  # Readable test descriptions
+  c.formatter = :documentation
+
+  # Configure all nodes in nodeset
+  c.before :suite do
+    # Install module and dependencies
+    puppet_module_install(
+      :source => proj_root,
+      :target_module_path => '/opt/boxen/',
+      :module_name => 'repo',
+    )
+    git_origin = `git config --get remote.origin.url`
+    hosts.each do |host|
+      shell('cd /opt/boxen/repo/; git init;', :acceptable_exit_codes => [0])
+      shell("cd /opt/boxen/repo/; git remote add origin #{git_origin}", :acceptable_exit_codes => [0])
+      shell('cd /opt/boxen/repo/; git fetch -q origin; git reset --hard origin/master;', :acceptable_exit_codes => [0])
+      shell('bash /opt/boxen/repo/script/setup-keychain.sh', :acceptable_exit_codes => [0])
+      shell('bash /opt/boxen/repo/script/xcode-cli-tools.sh', :acceptable_exit_codes => [0])
+      shell('sudo gem install rake -v 10.3.2 --force', :acceptable_exit_codes => [0])
+      shell('cd /opt/boxen/repo/; script/bootstrap --deployment --local --without development:test --no-cache', :acceptable_exit_codes => [0])
+      shell('cd /opt/boxen/repo/; /usr/bin/bundle install --binstubs bin --path .bundle --quiet', :acceptable_exit_codes => [0])
+    end
+  end
+end


### PR DESCRIPTION
I need to clean up the setup a bit more

This adds support to run acceptance tests using [Beaker](http://github.com/puppetlabs/beaker). This uses an OSX Vagrant box, runs the standard setup to get it working, then runs Boxen as the 'vagrant' user :+1: 

@dgoodlad any thoughts?

I'll add a README.md for the acceptance test too to say how to setup and such :smile: 
