### PR TITLE
Small fix on Redis section on rails.md

### DIFF
--- a/docs/rails.md
+++ b/docs/rails.md
@@ -113,7 +113,7 @@ test:
 ``` ruby
 # config/initializers/redis.rb
 
-$redis = Redis.new(ENV['BOXEN_REDIS_URL'] || 'redis://localhost:6379/')
+$redis = Redis.new(url: (ENV['BOXEN_REDIS_URL'] || 'redis://localhost:6379/'))
 ```
 
 ### Elasticsearch


### PR DESCRIPTION
Actually Redis needs to specify the url: parameter when using the URL, otherwise
needs to specify host:, port: so I kept the original example using the URL, but
now with the :url option