### PR TITLE
boxen-git-credential: handle /usr/local Homebrew.

### DIFF
--- a/script/boxen-git-credential
+++ b/script/boxen-git-credential
@@ -12,6 +12,8 @@ require "pathname"
 
 Encoding.default_external = Encoding::UTF_8 if RUBY_VERSION > "1.9"
 
+credential = `/usr/bin/which git-credential-osxkeychain`.chomp
+
 # Put us where we belong, in the root dir of our boxen repo.
 
 Dir.chdir Pathname.new(__FILE__).realpath + "../.."
@@ -40,7 +42,7 @@ else
   require "open4"
 
   fallback   = ENV["BOXEN_GIT_CREDENTIAL_FALLBACK"]
-  fallback ||= "#{config.homedir}/homebrew/bin/git-credential-osxkeychain"
+  fallback ||= credential
 
   status = Open4.popen4 fallback, *ARGV do |pid, stdin, stdout, stderr|
     stdin.write input


### PR DESCRIPTION
Don't assume the Git credential location as Homebrew might be in `/usr/local` and due to Boxen being Boxen we can't get the location in this script itself (as far as I can tell).

Closes #727.

CC @indirect @seanknox @salimane