### PR TITLE
updated git credential to use git subcommand

### DIFF
--- a/script/boxen-git-credential
+++ b/script/boxen-git-credential
@@ -12,7 +12,7 @@ require "pathname"
 
 Encoding.default_external = Encoding::UTF_8 if RUBY_VERSION > "1.9"
 
-credential = `/usr/bin/which git-credential-osxkeychain`.chomp
+credential = '/usr/bin/git credential-osxkeychain'
 
 # Put us where we belong, in the root dir of our boxen repo.
 


### PR DESCRIPTION
  * on a new os x install git-credential-osxkeychain is not a valid command
    so we should rely on the git subcommand instead which is just git credential-osxkeychain
  * this was an oversight because once boxen runs it installs this command as /usr/local/bin/git-credential-osxkeychain.