### PR TITLE
Fixed typo, consistent line breaks and code markup

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -3,9 +3,10 @@
 Below you can find common questions and answers.
 
 ### Q: Boxen Keychain Helper: Encountered error code: -25308
+
 If you run `boxen` in a session without GUI (e.g. via SSH), you will most likely need to unlock the keychain manually.
 
-```
+```bash
 security create-keychain -p $your_password $keychain_name
 security default-keychain -d user -s $keychain_name
 # if necessary..
@@ -21,20 +22,21 @@ When removing applications make sure to remove the corresponding `/var/db/.puppe
 Run `script/nuke` from inside the `/opt/boxen/repo` directory.
 
 ### Q: How do you upgrade your boxen from the public our-boxen?
-Anwser distilled from http://grahamgilbert.com/blog/2014/04/04/updating-boxen/
+
+Answer distilled from http://grahamgilbert.com/blog/2014/04/04/updating-boxen/
 As Boxen is made by GitHub, updating it is much like updating any other project on there that you’ve made a fork of. First we’re going to add it as a remote repository:
 
 ```bash
 cd ~/src/our-boxen
 git remote add upstream https://github.com/boxen/our-boxen.git
 ```
-Then we’re going to fetch the stuff from the upstream repository:
+Then we're going to fetch the stuff from the upstream repository:
 
 ```bash
 git fetch upstream
 ```
 
-Now we’re going to merge the updated repository with our own:
+Now we're going to merge the updated repository with our own:
 
 ```bash
 git checkout master
@@ -42,7 +44,6 @@ git merge upstream/master
 ```
 
 Now deal with conflicts in (Puppetfile, manifests/site.pp), ignore any diffs in Puppetfile.lock and Gemfile.lock.
-
 
 ```bash
 git mergetool
@@ -55,7 +56,6 @@ rm Puppetfile.lock Gemfile.lock
 bundle install --no-deployment --without development --path .bundle
 bundle exec librarian-puppet install --clean
 ```
-
 
 ### Q: What's a good approach to merging our-boxen back into my private fork?
 


### PR DESCRIPTION
:information_desk_person: These changes fix a typo, adds a formatting hint and makes the linespacing consistent after headings (:bowtie:). It also changes the curly apostrophes used in the Stack Overflow quote/cut and paste to flat "'" for consistency with usage elsewhere.