### PR TITLE
Fix nodejs version numbering

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -64,9 +64,9 @@ node default {
   }
 
   # node versions
-  nodejs::version { 'v0.6': }
-  nodejs::version { 'v0.8': }
-  nodejs::version { 'v0.10': }
+  nodejs::version { '0.6': }
+  nodejs::version { '0.8': }
+  nodejs::version { '0.10': }
 
   # default ruby versions
   ruby::version { '1.9.3': }


### PR DESCRIPTION
The new puppet-nodejs modules no longer prefixes version aliases with a 'v'. The Puppetfile was updated with the newer module version but the manifest was not updated.