### PR TITLE
script/sync: don't use s3_cellar for node

### DIFF
--- a/script/sync
+++ b/script/sync
@@ -135,7 +135,7 @@ def sync_ruby(version)
 end
 
 def sync_node(version)
-  s3_key = "nodes/Darwin/#{s3_cellar}#{os}/#{version}.tar.bz2"
+  s3_key = "nodes/Darwin/#{os}/#{version}.tar.bz2"
   tempfile = Tempfile.new "boxen-nodejs"
 
   return if object_exists?(s3_key)


### PR DESCRIPTION
This isn't needed as there are no references to Homebrew's Cellar (unlike Ruby): https://github.com/boxen/our-boxen/pull/739/files#r32968835.

CC @blackjid for thoughts.