### PR TITLE
Include `git clean` for getting back to golden path

### DIFF
--- a/script/boxen
+++ b/script/boxen
@@ -106,6 +106,7 @@ elsif !%x(git status --porcelain).chomp.empty?
     back on the golden path:
 
       cd #{Dir.pwd}
+      git clean -df
       git reset --hard origin/master
       boxen
   END


### PR DESCRIPTION
The instructions on how to get back to the golden path have been updated to
include a `git clean` which will remove any files which are not already under
version control and stop the `git status` check from spewing out untracked
files.