### PR TITLE
nuke: remove Boxen taps if in /usr/local.

### DIFF
--- a/script/nuke
+++ b/script/nuke
@@ -51,7 +51,7 @@ end
 
 if all || opt
   warn "-> Removing /opt/boxen."
-  system "rm", "-rf", "/opt/boxen" if force
+  system "rm", "-rf", "/opt/boxen", "/usr/local/Library/Taps/boxen" if force
 end
 
 if all || receipts


### PR DESCRIPTION
Otherwise this will mess with the future installation of Homebrew software.