### PR TITLE
Update installed versions of Node.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,9 @@ This template project provides the following by default:
 * dnsmasq w/ .dev resolver for localhost
 * rbenv
 * Full Disk Encryption requirement
-* Node.js 0.6
 * Node.js 0.8
 * Node.js 0.10
+* Node.js 0.12
 * Ruby 1.9.3
 * Ruby 2.0.0
 * Ruby 2.1.0

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -64,9 +64,9 @@ node default {
   }
 
   # node versions
-  nodejs::version { '0.6': }
   nodejs::version { '0.8': }
   nodejs::version { '0.10': }
+  nodejs::version { '0.12': }
 
   # default ruby versions
   ruby::version { '1.9.3': }


### PR DESCRIPTION
v0.6 does not compile on Mac OS X 10.11 due to missing openssl headers. It is also a very outdated version. Instead of installing v0.6 let's install v0.12. v0.12 is the latest version available via puppet-nodejs 5.0.0.

Fixes #778.