### PR TITLE
Update `PATH` to include correct bundler version

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -53,14 +53,12 @@ fi
 set -e
 
 # FIX: only sudo if gem home isn't writable
-
-(/usr/bin/gem spec bundler -v '~> 1.5.3' >/dev/null 2>&1) || {
+(/usr/bin/gem spec bundler -v '~> 1.10.5' >/dev/null 2>&1) || {
     log "====> Installing bundler to system ruby"
     /usr/bin/sudo -p "Password for sudo to install bundler: " \
-        /usr/bin/gem install bundler -v '~> 1.5.3' --no-rdoc --no-ri
+        /usr/bin/gem install bundler -v '~> 1.10.5' --no-rdoc --no-ri
 }
-PATH="/Library/Ruby/bin:$PATH"
-
+PATH="/Library/Ruby/bin:$(gem which bundler | sed -e 's!lib/bundler.rb!bin!'):$PATH"
 # Use checksums to quickly determine if we need to re-bundle
 
 checksum_bundle() {


### PR DESCRIPTION
After upgrading to El Capitan bundler could not be found within `$PATH` which
caused gem installation issues. To fix this, the `$PATH` has been updated to
include the correct path for bundler. Along with this change, I've bumped the
version of bundler used because 1.5.3 is outdated by a couple of years now.

The original patches can be found at https://github.com/boxen/our-boxen/issues/794#issuecomment-159541053

Fixes #794.

/cc @henscu @lyzadanger @fivetanley @abuxton to please test this on your
machines and confirm this works as expected.