### PR TITLE
Document passing --path to librarian-puppet in FAQ

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -54,7 +54,7 @@ The next step is to update your Puppet modules and RubyGems. First delete Puppet
 ```bash
 rm Puppetfile.lock Gemfile.lock
 bundle install --no-deployment --without development --path .bundle
-bundle exec librarian-puppet install --clean
+bundle exec librarian-puppet install --path=shared --clean
 ```
 
 ### Q: What's a good approach to merging our-boxen back into my private fork?
@@ -65,7 +65,7 @@ One approach is to delete the Gemfile.lock and Puppetfile.lock and run:
     bundle install --without development --path .bundle
 
     # Regenerates Puppetfile.lock and caches tarballs
-    bundle exec librarian-puppet install --clean
+    bundle exec librarian-puppet install --path=shared --clean
 
 These will generate the respective lock files suitable for committing. Hope that helps.
 


### PR DESCRIPTION
Closes #789.

If the `--path` option is omitted, librarian-puppet will install modules to its default path, which will then clash with the ones installed by Boxen.

~~I've also removed a second redundant FAQ entry about updating from upstream - it had all the same information, just with less detail.~~