### PR TITLE
Send path fixes upstream

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -46,6 +46,7 @@ set -e
 # native extensions won't fail, e.g. json
 # See https://developer.apple.com/library/ios/releasenotes/developertools/rn-xcode/Introduction/Introduction.html
 set +e
+PATH=${PATH}:/usr/sbin
 CLTOOLS_VERSION_CHECK=`pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '/^version:/ {print $2}' | egrep -q '^5\.1' 2>/dev/null`
 if [ $? -eq 0 ]; then
     export ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -60,7 +60,7 @@ set -e
 }
 PATH="/Library/Ruby/bin:$(gem which bundler | sed -e 's!lib/bundler.rb!bin!'):$PATH"
 # Use checksums to quickly determine if we need to re-bundle
-
+PATH=${PATH}:/sbin
 checksum_bundle() {
     (((find Gemfile Gemfile.lock bin -type f) | xargs cat) && /usr/bin/ruby -v && bundle -v) | md5
 }


### PR DESCRIPTION
# Context

Getting the latest `script/bootstrap` into our fork broke. I fixed this locally when I upgaded to El Capitan but forgot to send it upstream.

# Change

Reapply `PATH` fixes for El Capitan, etc, from envato#2210

# Considerations

I considered combining `PATH=${PATH}:/usr/sbin:/sbin` atop the file but ultimately chose to put the `PATH` updates close to where they are used. This makes the context clearer (to me) but also will facilitate refactoring.

# Cc

@jacobbednarz