### PR TITLE
WIP Fix CI for ruby 2.0 (osx 10.12)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,21 @@
 os:
-- osx
+  - osx
+osx_image:
+  - xcoode9.2
 script:
-- rm -rf /usr/local/Homebrew
-- travis_wait 60 rvm implode --force
-- ./script/boxen --no-fde --stealth --no-pull --debug --profile --login $BOXEN_GITHUB_LOGIN --token $BOXEN_GITHUB_TOKEN || test $? -eq 2
-- source /opt/boxen/env.sh
-- bundle exec rspec spec
+  - 'if [ -n "$BOXEN_GITHUB_TOKEN" ]; then
+      ./script/boxen --no-fde --stealth --no-pull --debug --profile --login $BOXEN_GITHUB_LOGIN --token $BOXEN_GITHUB_TOKEN || test $? -eq 2;
+    else
+      ./script/boxen --no-fde --stealth --no-pull --debug --profile || test $? -eq 2;
+  fi'
+  - source /opt/boxen/env.sh
+  - bundle exec rspec spec
 before_install:
-- sudo gem install bundler -v '~> 1.13'
+  - rvm list rubies
+  - rvm install 2.0.0
+  - rvm use 2.0.0
+  - gem install bundler -v '~> 1.10.5'
 env:
   global:
     - HOMEBREW_NO_AUTO_UPDATE=1
     - HOMEBREW_VERBOSE=1
-    - secure: HoCPuAgujmw+tdH7qq9bSymtpE8o4gpp1uYRyFin2TB3px2JdOPCPCb754vddmE12zhhKKSy1j0Uj/qeW6tjy9hIhlAjLAGFuT+mNTURqu4nmojCgKO2ApcRWc3yv319XR2vjUDW1qmEyKm7il4q1c/dOFmGbVYeDixjUUfWVII=


### PR DESCRIPTION
- Support ruby 2.0 with new openssl
- Ruby 2.0 is not installed osx container (ruby 2.4 or above)
